### PR TITLE
fix(security): Trivy legacy Dockerfile path and Safety CI installs

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v7.1.0
         with:
           context: .
-          file: services/decision-api/Dockerfile
+          file: legacy_attic/services/legacy_v1_decision_api/Dockerfile
           load: true
           tags: tarka/decision-api:scan
           push: false

--- a/scripts/ci/safety_scan_services.sh
+++ b/scripts/ci/safety_scan_services.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-: "${SAFETY_VERSION:=2.3.5}"
+# Use :- so an empty SAFETY_VERSION in the environment does not expand to `safety==` (which installs Safety 3.x).
+SAFETY_VERSION="${SAFETY_VERSION:-2.3.5}"
 any_failed=0
 
 while IFS= read -r -d '' pyproject; do
@@ -29,9 +30,11 @@ while IFS= read -r -d '' pyproject; do
       installed=1
     fi
   else
-    if python -m pip install -q -e "${ROOT}/${rel}[dev]" 2>/dev/null; then
+    # Install from the project directory so PEP 508 ``file:../../../…`` path deps resolve to the repo,
+    # not the runner home directory (pip + cwd edge cases when ``-e`` is passed as an absolute path).
+    if (cd "${ROOT}/${rel}" && python -m pip install -q -e ".[dev]") 2>/dev/null; then
       installed=1
-    elif python -m pip install -q -e "${ROOT}/${rel}"; then
+    elif (cd "${ROOT}/${rel}" && python -m pip install -q -e "."); then
       installed=1
     fi
   fi


### PR DESCRIPTION
## Summary
- Point **Trivy decision-api image** build at `legacy_attic/services/legacy_v1_decision_api/Dockerfile` (post–#184 layout).
- Fix **Dependency CVE scan** (`safety_scan_services.sh`): pin Safety **2.3.5** when `SAFETY_VERSION` is empty; install editable projects from each `pyproject.toml` directory so `file:../../../packages/…` deps resolve on runners.

## Test plan
- [ ] `Security scan` workflow green (Trivy filesystem + decision-api image)
- [ ] `Dependency CVE scan` workflow green (Python safety job)
- [ ] Dependabot PRs #185–#187 security checks pass after merge